### PR TITLE
make oth field optional

### DIFF
--- a/src/jwk.rs
+++ b/src/jwk.rs
@@ -61,8 +61,8 @@ pub struct Jwk {
     pub dq: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub qi: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub oth: Option<Vec<Value>>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub oth: Vec<Value>,
 }
 
 impl Jwk {
@@ -153,14 +153,14 @@ impl Jwk {
                             self.dp.as_deref(),
                             self.dq.as_deref(),
                             self.qi.as_deref(),
-                            self.oth.as_deref(),
+                            self.oth.is_empty(),
                         ) {
-                            (None, None, None, None, None, None) => {
+                            (None, None, None, None, None, true) => {
                                 let rsa = RsaPrivateKeyBuilder::new(n, e, d)?.build();
                                 let pkey = PKey::from_rsa(rsa)?;
                                 RsaPrivateKey::from_pkey_without_check(pkey, alg).map(Into::into)
                             }
-                            (Some(p), Some(q), Some(dp), Some(dq), Some(qi), None) => {
+                            (Some(p), Some(q), Some(dp), Some(dq), Some(qi), true) => {
                                 let p = decode(p)?;
                                 let q = decode(q)?;
                                 let dp = decode(dp)?;

--- a/src/jwk.rs
+++ b/src/jwk.rs
@@ -61,8 +61,8 @@ pub struct Jwk {
     pub dq: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub qi: Option<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub oth: Vec<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub oth: Option<Vec<Value>>,
 }
 
 impl Jwk {
@@ -153,14 +153,14 @@ impl Jwk {
                             self.dp.as_deref(),
                             self.dq.as_deref(),
                             self.qi.as_deref(),
-                            self.oth.is_empty(),
+                            self.oth.as_deref(),
                         ) {
-                            (None, None, None, None, None, true) => {
+                            (None, None, None, None, None, None) => {
                                 let rsa = RsaPrivateKeyBuilder::new(n, e, d)?.build();
                                 let pkey = PKey::from_rsa(rsa)?;
                                 RsaPrivateKey::from_pkey_without_check(pkey, alg).map(Into::into)
                             }
-                            (Some(p), Some(q), Some(dp), Some(dq), Some(qi), true) => {
+                            (Some(p), Some(q), Some(dp), Some(dq), Some(qi), None) => {
                                 let p = decode(p)?;
                                 let q = decode(q)?;
                                 let dp = decode(dp)?;


### PR DESCRIPTION
When trying to integrate this with Keycloak I found that its jwks endpoint omits the "oth" field entirely.  If I'm reading this RFC correctly, it seems like unless multi-prime keys are supported any key with that field should be dropped

https://datatracker.ietf.org/doc/html/rfc7518#section-6.3.2.7

In any case, this was the change I made to fix the issue in my environment