### PR TITLE
feat: implement Clone for HeaderAndClaims

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ pub mod jwk;
 
 /// JWT header.
 #[non_exhaustive]
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub struct Header {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub typ: Option<String>,
@@ -113,7 +113,7 @@ impl<'a, T> Iterator for OneOrManyIter<'a, T> {
 #[serde_as]
 #[skip_serializing_none]
 #[non_exhaustive]
-#[derive(Debug, Serialize, Default, Deserialize)]
+#[derive(Clone, Debug, Serialize, Default, Deserialize)]
 pub struct Claims<ExtraClaims> {
     #[serde_as(as = "Option<serde_with::DurationSeconds<f64>>")]
     pub exp: Option<Duration>,
@@ -139,7 +139,7 @@ pub struct Claims<ExtraClaims> {
 /// Use `serde_json::Map<String, Value>` for dynamic claims.
 ///
 /// Or define your own claims type which implements `Serialize`/`Deserialize`.
-#[derive(Default, Debug)]
+#[derive(Clone, Default, Debug)]
 pub struct HeaderAndClaims<ExtraClaims> {
     header: Header,
     claims: Claims<ExtraClaims>,


### PR DESCRIPTION
In my Axum JWT verification middleware, I want to pass the validated JWT on to successive middlewares and handlers. This is done by adding it to the `request.extensions()` type map. However, it requires `T: Clone` and `HeaderAndClaims<_>` currently does not implement `Clone` so this is not directly possible.

This PR implements the relevant `Clone` which spares the minor inconvenience of having to put the JWT in an `Arc`. A quick test indicates that this will grow the release rlib by 4 kbytes (current rlib is c:a 1.1 Mbytes). Not sure if this is a reasonable trade-off, but since I wrote and tested the code, I thought I'd put it up for consideration.