### PR TITLE
feat: Builder for remote verifier

### DIFF
--- a/examples/jwks_client.rs
+++ b/examples/jwks_client.rs
@@ -4,7 +4,6 @@ async fn main() -> jwtk::Result<()> {
     use jwtk::jwk::RemoteJwksVerifier;
     use serde::Deserialize;
     use serde_json::{Map, Value};
-    use std::time::Duration;
 
     #[derive(Deserialize)]
     struct Token {
@@ -16,11 +15,7 @@ async fn main() -> jwtk::Result<()> {
         .json()
         .await?;
 
-    let j = RemoteJwksVerifier::new(
-        "http://127.0.0.1:3000/jwks".into(),
-        None,
-        Duration::from_secs(300),
-    );
+    let j = RemoteJwksVerifier::new("http://127.0.0.1:3000/jwks".into());
     let c = j.verify::<Map<String, Value>>(&v.token).await?;
 
     println!("headers:\n{}", serde_json::to_string(c.header())?);

--- a/src/jwk.rs
+++ b/src/jwk.rs
@@ -527,6 +527,7 @@ impl RemoteJwksVerifier {
     }
 }
 
+#[cfg(feature = "remote-jwks")]
 pub struct RemoteJwksVerifierBuilder {
     url: String,
     client: Option<reqwest::Client>,
@@ -534,6 +535,7 @@ pub struct RemoteJwksVerifierBuilder {
     require_kid: bool,
 }
 
+#[cfg(feature = "remote-jwks")]
 impl RemoteJwksVerifierBuilder {
     /// Provide an HTTP client for fetching the JWK set.
     pub fn with_client(mut self, client: reqwest::Client) -> Self {


### PR DESCRIPTION
This means the caller will not have to care about values with defaults. This was prompted by discussion in #8.

This is a breaking change since it updates the existing constructor to use default values.